### PR TITLE
UAA case insensitivity

### DIFF
--- a/organization/orgs.go
+++ b/organization/orgs.go
@@ -208,7 +208,7 @@ func (m *DefaultOrgManager) updateUsers(ldapMgr ldap.Manager, uaacMgr uaac.Manag
 		if groupUsers, err = ldapMgr.GetUserIDs(groupName); err == nil {
 			if uaacUsers, err = uaacMgr.ListUsers(); err == nil {
 				for _, groupUser := range groupUsers {
-					if _, userExists := uaacUsers[groupUser.UserID]; userExists {
+					if _, userExists := uaacUsers[strings.ToLower(groupUser.UserID)]; userExists {
 						lo.G.Info("User", groupUser.UserID, "already exists")
 					} else {
 						lo.G.Info("User", groupUser.UserID, "doesn't exist so creating in UAA")

--- a/space/spaces.go
+++ b/space/spaces.go
@@ -259,7 +259,7 @@ func (m *DefaultSpaceManager) updateUsers(ldapMgr ldap.Manager, uaacMgr uaac.Man
 		if groupUsers, err = ldapMgr.GetUserIDs(groupName); err == nil {
 			if uaacUsers, err = uaacMgr.ListUsers(); err == nil {
 				for _, groupUser := range groupUsers {
-					if _, userExists := uaacUsers[groupUser.UserID]; userExists {
+					if _, userExists := uaacUsers[strings.ToLower(groupUser.UserID)]; userExists {
 						lo.G.Info("User", groupUser.UserID, "already exists")
 					} else {
 						lo.G.Info("User", groupUser.UserID, "doesn't exist so creating in UAA")


### PR DESCRIPTION
When the Active Directory user/CN is mixed case, the comparison function was not correctly matching the UAA user with the AD user.  An error occurred.
[Example](https://gist.github.com/skibum55/04bc1af81e3e28b520f1cdaa14a4f075)

This patch lower cases the strings involved in the comparison.  No tests :-(