### PR TITLE
Add more error output on ldap connect and search errors

### DIFF
--- a/ldap/ldap.go
+++ b/ldap/ldap.go
@@ -60,10 +60,9 @@ func (m *DefaultManager) getLdapConnection(config *Config) (*l.Conn, error) {
 func (m *DefaultManager) GetUserIDs(config *Config, groupName string) (users []User, err error) {
 	var ldapConnection *l.Conn
 	if ldapConnection, err = m.getLdapConnection(config); err == nil {
-		// be sure to add error checking!
 		defer ldapConnection.Close()
 		if err = ldapConnection.Bind(config.BindDN, config.BindPassword); err != nil {
-			return
+			return nil, err
 		}
 		var groupEntry *l.Entry
 		var user *User
@@ -83,13 +82,14 @@ func (m *DefaultManager) GetUserIDs(config *Config, groupName string) (users []U
 				lo.G.Info("Group not found", groupName)
 			}
 		}
+	} else {
+		return nil, err
 	}
 	return
 }
 
 func (m *DefaultManager) GetLdapUser(config *Config, userDN, userSearchBase string) (*User, error) {
 	if ldapConnection, err := m.getLdapConnection(config); err == nil {
-		// be sure to add error checking!
 		defer ldapConnection.Close()
 		if err := ldapConnection.Bind(config.BindDN, config.BindPassword); err != nil {
 			return nil, err

--- a/ldap/ldap_test.go
+++ b/ldap/ldap_test.go
@@ -55,6 +55,17 @@ var _ = Describe("Ldap", func() {
 				LdapPort:          port,
 			}
 		})
+		Context("when ldap is unreachable", func() {
+			BeforeEach(func() { config.LdapHost = "unreachable-host" })
+			It("then GetUserIDs should return an error", func() {
+				_, err := ldapManager.GetUserIDs(config, "space_developers")
+				Ω(err).ShouldNot(BeNil())
+			})
+			It("then GetUserIDs should return an error", func() {
+				_, err := ldapManager.GetLdapUser(config, "cn=Washburn, Caleb,ou=users,dc=pivotal,dc=org", "ou=users,dc=pivotal,dc=org")
+				Ω(err).ShouldNot(BeNil())
+			})
+		})
 		Context("when cn with special characters", func() {
 			It("then it should return 1 Entry", func() {
 				entry, err := ldapManager.GetLdapUser(config, "cn=Washburn, Caleb,ou=users,dc=pivotal,dc=org", "ou=users,dc=pivotal,dc=org")

--- a/organization/orgs.go
+++ b/organization/orgs.go
@@ -232,6 +232,9 @@ func (m *DefaultOrgManager) getLdapUsers(config *ldap.Config, groupName string, 
 	if groupName != "" {
 		if groupUsers, err := m.LdapMgr.GetUserIDs(config, groupName); err == nil {
 			users = append(users, groupUsers...)
+		} else {
+			lo.G.Error(err)
+			return nil, err
 		}
 	}
 	for _, user := range userList {
@@ -240,6 +243,7 @@ func (m *DefaultOrgManager) getLdapUsers(config *ldap.Config, groupName string, 
 				users = append(users, *ldapUser)
 			}
 		} else {
+			lo.G.Error(err)
 			return nil, err
 		}
 	}

--- a/space/spaces.go
+++ b/space/spaces.go
@@ -269,6 +269,9 @@ func (m *DefaultSpaceManager) getLdapUsers(config *ldap.Config, groupName string
 	if groupName != "" {
 		if groupUsers, err := m.LdapMgr.GetUserIDs(config, groupName); err == nil {
 			users = append(users, groupUsers...)
+		} else {
+			lo.G.Error(err)
+			return nil, err
 		}
 	}
 	for _, user := range userList {


### PR DESCRIPTION
Add more error output for ldap connect and search functions to allow easier troubleshoot such errors.