### PR TITLE
Fix issue 33

### DIFF
--- a/space/users.go
+++ b/space/users.go
@@ -132,7 +132,7 @@ func (m *UserManager) updateLdapUser(config *ldap.Config, spaceGUID, orgGUID str
 			}
 		}
 	} else {
-		delete(spaceUsers, strings.ToLower(user.UserID))
+		delete(spaceUsers, userID)
 	}
 	return nil
 }

--- a/uaac/uaac.go
+++ b/uaac/uaac.go
@@ -33,7 +33,7 @@ func (m *DefaultUAACManager) CreateExternalUser(userName, userEmail, externalID,
 	return nil
 }
 
-//ListUsers - Returns a map containing username as key and username as value
+//ListUsers - Returns a map containing username as key and user guid as value
 func (m *DefaultUAACManager) ListUsers() (map[string]string, error) {
 	userIDMap := make(map[string]string)
 	usersList, err := getUsers(m.Host, m.UUACToken)


### PR DESCRIPTION
This fixes issue #33  where LDAP users were getting incorrectly removed from CF when the LDAP configuration `Origin` was set to something besides `ldap`.