### PR TITLE
Feature/delete orgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,8 +198,19 @@ After running the above commands, there will be a config directory in the workin
 ```
 
 #### Org Configuration
-There is a orgs.yml that contains list of orgs that will be created.  This should have a corresponding folder with name of the orgs cf-mgmt is managing.  This will contain a orgConfig.yml and folder for each space.  Each orgConfig.yml consists of the following.
+There is a orgs.yml that contains list of orgs that will be created.  This should have a corresponding folder with name of the orgs cf-mgmt is managing. orgs.yml also can be configured with a list of protected orgs which would never be deleted when using the the `delete-orgs` command. An example of how orgs.yml could be configured is seen below.
 
+```
+orgs:
+- foo-org
+- bar-org
+protected_orgs:
+- system
+- p-spring-cloud-services
+
+```
+
+This will contain a orgConfig.yml and folder for each space.  Each orgConfig.yml consists of the following.
 ```
 # org name
 org: test
@@ -376,6 +387,11 @@ To execute any of the following you will need to provide:
 
 #### create-orgs
 - creates orgs specified in orgs.yml
+
+#### delete-orgs
+- deletes orgs NOT specified in orgs.yml.  This is recursive for underlaying spaces and apps.
+- Will NOT delete orgs which are `protected_orgs` in orgs.yml
+- specifying `--peek` will show you which orgs would be deleted, without actually deleting them.
 
 #### update-org-quotas
 - updates org quotas specified in orgConfig.yml

--- a/integration/fixture/orgs.yml
+++ b/integration/fixture/orgs.yml
@@ -1,3 +1,6 @@
 orgs:
 - test1
 - test2
+protected_orgs:
+- system
+- pcfdev-org

--- a/main.go
+++ b/main.go
@@ -140,6 +140,7 @@ func NewApp(eh *ErrorHandler) *cli.App {
 		CreateExportConfigCommand(eh),
 		CreateGeneratePipelineCommand(runGeneratePipeline, eh),
 		CreateCommand("create-orgs", runCreateOrgs, defaultFlags(), eh),
+		CreateCommand("delete-orgs", runDeleteOrgs, defaultFlags(), eh),
 		CreateCommand("update-org-quotas", runCreateOrgQuotas, defaultFlags(), eh),
 		CreateCommand("update-org-users", runUpdateOrgUsers, defaultFlagsWithLdap(), eh),
 		CreateCommand("create-spaces", runCreateSpaces, defaultFlagsWithLdap(), eh),
@@ -384,6 +385,16 @@ func runCreateOrgs(c *cli.Context) error {
 	}
 	return err
 }
+
+func runDeleteOrgs(c *cli.Context) error {
+	var cfMgmt *CFMgmt
+	var err error
+	if cfMgmt, err = InitializeManager(c); err == nil {
+		err = cfMgmt.OrgManager.DeleteOrgs(cfMgmt.ConfigDirectory)
+	}
+	return err
+}
+
 
 func runCreateOrgQuotas(c *cli.Context) error {
 	var cfMgmt *CFMgmt

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ type CFMgmt struct {
 	SpaceManager    space.Manager
 	ConfigManager   config.Manager
 	ConfigDirectory string
-	PeekDeletion		bool
+	PeekDeletion    bool
 	LdapBindPwd     string
 	UaacToken       string
 	SystemDomain    string

--- a/main.go
+++ b/main.go
@@ -99,7 +99,6 @@ const (
 	configDirectory  string = "CONFIG_DIR"
 	orgName          string = "ORG"
 	spaceName        string = "SPACE"
-	peek						 bool   = false
 	ldapPassword     string = "LDAP_PASSWORD"
 	orgBillingMgrGrp string = "ORG_BILLING_MGR_GRP"
 	orgMgrGrp        string = "ORG_MGR_GRP"

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ type CFMgmt struct {
 	SpaceManager    space.Manager
 	ConfigManager   config.Manager
 	ConfigDirectory string
+	PeekDeletion		bool
 	LdapBindPwd     string
 	UaacToken       string
 	SystemDomain    string
@@ -57,6 +58,7 @@ func InitializeManager(c *cli.Context) (*CFMgmt, error) {
 	pwd := c.String(getFlag(password))
 	secret := c.String(getFlag(clientSecret))
 	ldapPwd := c.String(getFlag(ldapPassword))
+	peek := c.Bool("peek")
 
 	if sysDomain == "" ||
 		user == "" ||
@@ -76,7 +78,7 @@ func InitializeManager(c *cli.Context) (*CFMgmt, error) {
 	if uaacToken, err = cfMgmt.UAAManager.GetUAACToken(secret); err != nil {
 		return nil, err
 	}
-
+	cfMgmt.PeekDeletion = peek
 	cfMgmt.ConfigDirectory = configDir
 	cfMgmt.UaacToken = uaacToken
 	cfMgmt.SystemDomain = sysDomain
@@ -97,6 +99,7 @@ const (
 	configDirectory  string = "CONFIG_DIR"
 	orgName          string = "ORG"
 	spaceName        string = "SPACE"
+	peek						 bool   = false
 	ldapPassword     string = "LDAP_PASSWORD"
 	orgBillingMgrGrp string = "ORG_BILLING_MGR_GRP"
 	orgMgrGrp        string = "ORG_MGR_GRP"
@@ -140,7 +143,7 @@ func NewApp(eh *ErrorHandler) *cli.App {
 		CreateExportConfigCommand(eh),
 		CreateGeneratePipelineCommand(runGeneratePipeline, eh),
 		CreateCommand("create-orgs", runCreateOrgs, defaultFlags(), eh),
-		CreateCommand("delete-orgs", runDeleteOrgs, defaultFlags(), eh),
+		CreateCommand("delete-orgs", runDeleteOrgs, defaultFlagsWithDelete(), eh),
 		CreateCommand("update-org-quotas", runCreateOrgQuotas, defaultFlags(), eh),
 		CreateCommand("update-org-users", runUpdateOrgUsers, defaultFlagsWithLdap(), eh),
 		CreateCommand("create-spaces", runCreateSpaces, defaultFlagsWithLdap(), eh),
@@ -390,7 +393,7 @@ func runDeleteOrgs(c *cli.Context) error {
 	var cfMgmt *CFMgmt
 	var err error
 	if cfMgmt, err = InitializeManager(c); err == nil {
-		err = cfMgmt.OrgManager.DeleteOrgs(cfMgmt.ConfigDirectory)
+		err = cfMgmt.OrgManager.DeleteOrgs(cfMgmt.ConfigDirectory, cfMgmt.PeekDeletion)
 	}
 	return err
 }
@@ -465,6 +468,16 @@ func defaultFlagsWithLdap() (flags []cli.Flag) {
 		Name:   getFlag(ldapPassword),
 		EnvVar: ldapPassword,
 		Usage:  "Ldap password for binding",
+	}
+	flags = append(flags, flag)
+	return
+}
+
+func defaultFlagsWithDelete() (flags []cli.Flag) {
+	flags = defaultFlags()
+	flag := cli.BoolFlag{
+		Name:   "peek",
+		Usage:  "Preview entities to delete without deleting them.",
 	}
 	flags = append(flags, flag)
 	return

--- a/organization/orgs.go
+++ b/organization/orgs.go
@@ -125,6 +125,19 @@ func (m *DefaultOrgManager) CreateOrgs(configDir string) error {
 	return nil
 }
 
+//DeleteOrgs -
+func (m *DefaultOrgManager) DeleteOrgs(configDir string) error {
+	configFile := filepath.Join(configDir, "orgs.yml")
+	lo.G.Info("Processing org file", configFile)
+	input := &InputOrgs{}
+	if err := m.UtilsMgr.LoadFile(configFile, input); err != nil {
+		return err
+	}
+
+	fmt.Println("Hi again")
+	return nil
+}
+
 func (m *DefaultOrgManager) DoesOrgExist(orgName string, orgs []*cloudcontroller.Org) bool {
 	for _, org := range orgs {
 		if org.Entity.Name == orgName {

--- a/organization/types.go
+++ b/organization/types.go
@@ -42,6 +42,7 @@ type MetaData struct {
 //InputOrgs -
 type InputOrgs struct {
 	Orgs []string `yaml:"orgs"`
+	ProtectedOrgs []string `yaml:"protected_orgs"`
 }
 
 //Contains -

--- a/organization/types.go
+++ b/organization/types.go
@@ -11,6 +11,7 @@ import (
 type Manager interface {
 	FindOrg(orgName string) (org *cloudcontroller.Org, err error)
 	CreateOrgs(configFile string) (err error)
+	DeleteOrgs(configFile string) (err error)
 	UpdateOrgUsers(configDir, ldapBindPassword string) (err error)
 	CreateQuotas(configDir string) (err error)
 	GetOrgGUID(orgName string) (orgGUID string, err error)

--- a/organization/types.go
+++ b/organization/types.go
@@ -11,7 +11,7 @@ import (
 type Manager interface {
 	FindOrg(orgName string) (org *cloudcontroller.Org, err error)
 	CreateOrgs(configFile string) (err error)
-	DeleteOrgs(configFile string) (err error)
+	DeleteOrgs(configFile string, peekDeletion bool) (err error)
 	UpdateOrgUsers(configDir, ldapBindPassword string) (err error)
 	CreateQuotas(configDir string) (err error)
 	GetOrgGUID(orgName string) (orgGUID string, err error)


### PR DESCRIPTION
This PR adds the ability to delete orgs.  The delete-orgs command makes use of the recursive flag on the CloudController API for deleting everything under that org as well.  Currently this feature is not implemented for generated concourse pipelines.  I may add that later, although given the destructive nature of delete-orgs, perhaps it shouldn't be inserted automatically unless someone is really looking to add that job to their pipeline.   

A user has the option to look at which orgs would be deleted without actually deleting them using the --peek flag.

Orgs which should not be deleted can be configured in orgs.yml under the protected_orgs key in list form.

I have added an integration test, I could use some help adding unit testing.  

Note. This is my first stab at working in Go, if things look odd or questionable please feel free to point that out. :) 
