### PR TITLE
When ldap users do not have an email, assign sentinel email

### DIFF
--- a/space/users.go
+++ b/space/users.go
@@ -110,6 +110,10 @@ func (m *UserManager) updateLdapUser(config *ldap.Config, spaceGUID, orgGUID str
 	if config.Origin != "ldap" {
 		userID = user.Email
 		externalID = user.Email
+	} else {
+		if user.Email == "" {
+			user.Email = fmt.Sprintf("%s@user.from.ldap.cf", userID)
+		}
 	}
 	userID = strings.ToLower(userID)
 


### PR DESCRIPTION
Produce consistent behavior with cf-mgmt and cf-cli.