### PR TITLE
Change the behavior of processing LDAP Users

### DIFF
--- a/organization/users.go
+++ b/organization/users.go
@@ -167,8 +167,7 @@ func (m *UserManager) getLdapUsers(config *ldap.Config, groupNames []string, use
 			if groupUsers, err := m.LdapMgr.GetUserIDs(config, groupName); err == nil {
 				users = append(users, groupUsers...)
 			} else {
-				lo.G.Error(err)
-				return nil, err
+				lo.G.Warning(err)
 			}
 		}
 	}


### PR DESCRIPTION
Change the conditional check of LdapMgr.GetUserIDs to log a warning on error but continue syncing, allowing other mapped AD groups to be synced in the foundation. This resolves https://github.com/pivotalservices/cf-mgmt/issues/94