### PR TITLE
Fix space creation when using SAML users

### DIFF
--- a/generated/files/pipeline.yml
+++ b/generated/files/pipeline.yml
@@ -101,7 +101,7 @@ jobs:
 - name: create-spaces
   plan:
   - get: config-repo
-    passed: [create-orgs]
+    passed: [create-orgs, update-org-users]
     trigger: true
   - task: create-spaces
     file: config-repo/ci/tasks/cf-mgmt.yml


### PR DESCRIPTION
Hi Caleb,

In this PR, we add a pre-condition so that the `create-spaces` runs after `update-org-users` has completed, because we SAML users must first be set up, before creating spaces.

Otherwise the pipeline gets blocked with an `invalid_password` error complaining with "Password
must be at least 1 characters in length."

Best