### PR TITLE
 Add appdynamics-org to the list of default protected orgs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -8,7 +8,7 @@ var DefaultProtectedOrgs = []string{
 	"p-spring-cloud-services",
 	"splunk-nozzle-org",
 	"redis-test-ORG*",
-    "appdynamics-org",
+	"appdynamics-org",
 }
 
 // Manager can read and write the cf-mgmt configuration.

--- a/config/config.go
+++ b/config/config.go
@@ -8,6 +8,7 @@ var DefaultProtectedOrgs = []string{
 	"p-spring-cloud-services",
 	"splunk-nozzle-org",
 	"redis-test-ORG*",
+    "appdynamics-org",
 }
 
 // Manager can read and write the cf-mgmt configuration.

--- a/config/yaml_config_test.go
+++ b/config/yaml_config_test.go
@@ -18,6 +18,7 @@ var _ = Describe("CF-Mgmt Config", func() {
 				Ω(config.DefaultProtectedOrgs).Should(ContainElement("p-spring-cloud-services"))
 				Ω(config.DefaultProtectedOrgs).Should(ContainElement("splunk-nozzle-org"))
 				Ω(config.DefaultProtectedOrgs).Should(ContainElement("redis-test-ORG*"))
+				Ω(config.DefaultProtectedOrgs).Should(ContainElement("appdynamics-org"))
 				Ω(config.DefaultProtectedOrgs).Should(HaveLen(4))
 			})
 		})


### PR DESCRIPTION
This prevents confusion when appd stops working every so often. If the org is deleted, no attached services instances can be deleted either.