### PR TITLE
Add support to add remove org(s) from protected orgs list

### DIFF
--- a/configcommands/update_orgs.go
+++ b/configcommands/update_orgs.go
@@ -10,7 +10,9 @@ import (
 type UpdateOrgsConfigurationCommand struct {
 	ConfigManager config.Manager
 	BaseConfigCommand
-	EnableDeleteOrgs string `long:"enable-delete-orgs" description:"Enable delete orgs option" choice:"true" choice:"false"`
+	EnableDeleteOrgs      string   `long:"enable-delete-orgs" description:"Enable delete orgs option" choice:"true" choice:"false"`
+	ProtectedOrgsToAdd    []string `long:"protected-org" description:"Add org(s) to protected org list, specify multiple times"`
+	ProtectedOrgsToRemove []string `long:"protected-org-to-remove" description:"Remove org(s) from protected org list, specify multiple times"`
 }
 
 //Execute - updates org configuration`
@@ -22,6 +24,7 @@ func (c *UpdateOrgsConfigurationCommand) Execute(args []string) error {
 	}
 	errorString := ""
 	convertToBool("enable-delete-orgs", &orgs.EnableDeleteOrgs, c.EnableDeleteOrgs, &errorString)
+	orgs.ProtectedOrgs = removeFromSlice(addToSlice(orgs.ProtectedOrgs, c.ProtectedOrgsToAdd, &errorString), c.ProtectedOrgsToRemove)
 
 	if errorString != "" {
 		return errors.New(errorString)

--- a/configcommands/update_orgs_test.go
+++ b/configcommands/update_orgs_test.go
@@ -55,9 +55,39 @@ var _ = Describe("given update orgs config command", func() {
 				ProtectedOrgs:    []string{"system", "my-special-org"},
 			}))
 		})
-
+		It("should succeed when adding org to protected org", func() {
+			configuration.ProtectedOrgsToAdd = []string{"apigee-edge-for-pcf-service-broker-org", "p-dataflow"}
+			mockConfig.OrgsReturns(&config.Orgs{
+				EnableDeleteOrgs: true,
+				Orgs:             []string{"foo", "bar"},
+				ProtectedOrgs:    []string{"system", "my-special-org"},
+			}, nil)
+			err := configuration.Execute(nil)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(mockConfig.SaveOrgsCallCount()).To(Equal(1))
+			Expect(mockConfig.SaveOrgsArgsForCall(0)).To(BeEquivalentTo(&config.Orgs{
+				EnableDeleteOrgs: true,
+				Orgs:             []string{"foo", "bar"},
+				ProtectedOrgs:    []string{"system", "my-special-org", "apigee-edge-for-pcf-service-broker-org", "p-dataflow"},
+			}))
+		})
+		It("should succeed when removing org to protected org", func() {
+			configuration.ProtectedOrgsToRemove = []string{"apigee-edge-for-pcf-service-broker-org", "p-dataflow"}
+			mockConfig.OrgsReturns(&config.Orgs{
+				EnableDeleteOrgs: true,
+				Orgs:             []string{"foo", "bar"},
+				ProtectedOrgs:    []string{"system", "my-special-org", "apigee-edge-for-pcf-service-broker-org", "p-dataflow"},
+			}, nil)
+			err := configuration.Execute(nil)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(mockConfig.SaveOrgsCallCount()).To(Equal(1))
+			Expect(mockConfig.SaveOrgsArgsForCall(0)).To(BeEquivalentTo(&config.Orgs{
+				EnableDeleteOrgs: true,
+				Orgs:             []string{"foo", "bar"},
+				ProtectedOrgs:    []string{"system", "my-special-org"},
+			}))
+		})
 	})
-
 	Context("Failures", func() {
 		It("should fail retrieving orgs", func() {
 			mockConfig.OrgsReturns(nil, errors.New("error retrieve"))


### PR DESCRIPTION
**Suggested verifications:**
1. cf-mgmt-config update-orgs -h
2. cf-mgmt-config update-orgs --config-dir ${config_dir} --protected-org apigee-edge-for-pcf-service-broker-org --protected-org p-dataflow
3. cf-mgmt-config update-orgs --config-dir ${config_dir} --protected-org-to-remove apigee-edge-for-pcf-service-broker-org --protected-org-to-remove p-dataflow
4. go test $(glide nv)