### PR TITLE
Clean-org-users prints client_secret

### DIFF
--- a/user/users.go
+++ b/user/users.go
@@ -333,7 +333,7 @@ func (m *DefaultManager) cleanupOrgUsers(uaaUsers *uaa.Users, input *config.OrgC
 		uaaUser := uaaUsers.GetByID(orgUser.Username)
 		var guid string
 		if uaaUser == nil {
-			lo.G.Infof("Unable to find users (%s) GUID from uaa using org user guid instead", orgUser)
+			lo.G.Infof("Unable to find users (%s) GUID from uaa using org user guid instead", orgUser.Username)
 			guid = orgUser.Guid
 		} else {
 			guid = uaaUser.GUID

--- a/user/users.go
+++ b/user/users.go
@@ -333,7 +333,7 @@ func (m *DefaultManager) cleanupOrgUsers(uaaUsers *uaa.Users, input *config.OrgC
 		uaaUser := uaaUsers.GetByID(orgUser.Username)
 		var guid string
 		if uaaUser == nil {
-			lo.G.Infof("Unable to find users (%s) GUID from uaa using org user guid instead", orgUser.Username)
+			lo.G.Infof("Unable to find user (%s) GUID from uaa, using org user guid instead", orgUser.Username)
 			guid = orgUser.Guid
 		} else {
 			guid = uaaUser.GUID


### PR DESCRIPTION
When the user cannot be found in UAA, the info message attempts to print the `orgUser` object as a string thus exposing the client_secret within the config.  The message itself was a little confusing so a little grammar clean up has been added.