### PR TITLE
Modified export command to exclude the export of DefaultProtectedOrgs[]

### DIFF
--- a/commands/export_config.go
+++ b/commands/export_config.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"github.com/pivotalservices/cf-mgmt/config"
 	"github.com/pivotalservices/cf-mgmt/export"
 	"github.com/xchapter7x/lo"
 )
@@ -29,7 +30,9 @@ func (c *ExportConfigurationCommand) Execute([]string) error {
 			cfMgmt.ServiceAccessManager,
 		  cfMgmt.QuotaManager)
 		excludedOrgs := make(map[string]string)
-		excludedOrgs["system"] = "system"
+		for _, org := range config.DefaultProtectedOrgs {
+			excludedOrgs[org] = org
+		}
 		for _, org := range c.ExcludedOrgs {
 			excludedOrgs[org] = org
 		}
@@ -37,7 +40,7 @@ func (c *ExportConfigurationCommand) Execute([]string) error {
 		for _, space := range c.ExcludedSpaces {
 			excludedSpaces[space] = space
 		}
-		lo.G.Info("Orgs excluded from export by default: [system]")
+		lo.G.Infof("Orgs excluded from export by default: %v ", config.DefaultProtectedOrgs)
 		lo.G.Infof("Orgs excluded from export by user:  %v ", c.ExcludedOrgs)
 		lo.G.Infof("Spaces excluded from export by user:  %v ", c.ExcludedSpaces)
 		err = exportManager.ExportConfig(excludedOrgs, excludedSpaces)

--- a/export/exportconfig.go
+++ b/export/exportconfig.go
@@ -129,7 +129,7 @@ func (im *DefaultImportManager) ExportConfig(excludedOrgs map[string]string, exc
 	for _, org := range orgs {
 		orgName := org.Name
 		if _, ok := excludedOrgs[orgName]; ok {
-			lo.G.Infof("Skipping org: %s as it is ignored from import", orgName)
+			lo.G.Infof("Skipping org: %s as it is ignored from export", orgName)
 			continue
 		}
 
@@ -238,7 +238,7 @@ func (im *DefaultImportManager) ExportConfig(excludedOrgs map[string]string, exc
 		for _, orgSpace := range spaces {
 			spaceName := orgSpace.Name
 			if _, ok := excludedSpaces[spaceName]; ok {
-				lo.G.Infof("Skipping space: %s as it is ignored from import", spaceName)
+				lo.G.Infof("Skipping space: %s as it is ignored from export", spaceName)
 				continue
 			}
 			lo.G.Infof("Processing space: %s", spaceName)


### PR DESCRIPTION
Failing to exclude protected orgs (e.g. p-spring-cloud-services) when exporting can cause problems when applying the config. It appears that service_access handles these orgs in a separate step, and therefore if they exist in your config apply will attempt to set service visibility more than once for the same org and will throw an error.

Given that these protected orgs are typically not managed in the same way as user-defined orgs, it made sense to simply exclude them from the export altogether, although I realize there could be another fix in cleaning up the aforementioned logic in service_access.