### PR TITLE
Switchout doc reference golang uaa cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Don't forget to `chmod +x` the file on Linux and macOS.
 
 ### Create UAA Client
 
-cf-mgmt needs a uaa client to be able to interact with cloud controller and uaa for create, updating, deleting, and listing entities.  
+cf-mgmt needs a uaa client to be able to interact with cloud controller and uaa for create, updating, deleting, and listing entities.
 
 ```
 uaac target uaa.<your system domain>
@@ -129,15 +129,14 @@ RUN_LDAP_TESTS=true go test ./ldap_integration/...
 ```
 
 The remaining integration tests require [PCF Dev](https://pivotal.io/pcf-dev)
-to be running and the CF CLI to be installed.
+to be running, the CF CLI, and the [UAA CLI](https://github.com/cloudfoundry-incubator/uaa-cli).
 
-```
+```sh
 cf dev start
-uaac target uaa.local.pcfdev.io
-uaac token client get admin -s admin-client-secret
-uaac client add cf-mgmt \
-  --name cf-mgmt \
-  --secret cf-mgmt-secret \
+uaa target http://uaa.local.pcfdev.io
+uaa get-client-credentials-token admin -s admin-client-secret
+uaa create-client cf-mgmt \
+  --client_secret cf-mgmt-secret \
   --authorized_grant_types client_credentials,refresh_token \
   --authorities cloud_controller.admin,scim.read,scim.write,routing.router_groups.read
 RUN_INTEGRATION_TESTS=true go test ./integration/...

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,15 +4,28 @@ The following commands are enabled with cf-mgmt that will leverage configuration
 
 ## Authentication requirements
 
-Introduced in cf-mgmt 0.0.66+ is the ability to definee a non admin uaa client.  With this release the password field has been deprecated. To create a non-admin client execute the following command with [Cloud Foundry UAA Client](https://docs.pivotal.io/pivotalcf/1-11/adminguide/uaa-user-management.html).  
+Introduced in cf-mgmt 0.0.66+ is the ability to definee a non admin uaa client.  With this release the password field has been deprecated. To create a non-admin client execute the following command with [Cloud Foundry UAA Client](https://github.com/cloudfoundry/cf-uaac).
 
-```
+```sh
 $ uaac target uaa.<system-domain>
 $ uaac token client get <adminuserid> -s <admin-client-secret>
 
 $ uaac client add cf-mgmt \
   --name cf-mgmt \
   --secret <cf-mgmt-secret> \
+  --authorized_grant_types client_credentials,refresh_token \
+  --authorities cloud_controller.admin,scim.read,scim.write
+```
+
+Or with the [golang-based UAA CLI](https://github.com/cloudfoundry-incubator/uaa-cli):
+
+```sh
+$ uaa target https://uaa.<system-domain>
+
+$ uaa get-client-credentials-token <adminuserid> -s <admin-client-secret>
+
+$ uaa create-client cf-mgmt \
+  --client_secret <cf-mgmt-secret> \
   --authorized_grant_types client_credentials,refresh_token \
   --authorities cloud_controller.admin,scim.read,scim.write
 ```

--- a/generated/files/vars.yml
+++ b/generated/files/vars.yml
@@ -1,13 +1,13 @@
-#your git repo uri
+# your git repo uri
 git_repo_uri:
 git_repo_branch: master
-#your cf system domain
+# your cf system domain
 system_domain:
 # user account with permission to create orgs/spaces
 user_id:
 # DEPRECATED - Use client_secret - password of user account with permission to create orgs/spaces
 password: ""
-# client secret for uaac for user_id
+# client secret for uaa for user_id
 client_secret:
 # password to bind to ldap - only needed if using LDAP
 ldap_password: ""


### PR DESCRIPTION
In order to consume the usage of the [golang-based uaa-cli](https://github.com/cloudfoundry-incubator/uaa-cli/issues/30#issuecomment-507390786) (rather than ruby-based `uaac`), the doc could be updated to include commands for `uaa-cli`.

(Completely understand if this is something you don't accept / don't want to swap out uaac with uaa-cli)