### PR TITLE
Fixup uaac to uaa example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,25 @@ Don't forget to `chmod +x` the file on Linux and macOS.
 
 cf-mgmt needs a uaa client to be able to interact with cloud controller and uaa for create, updating, deleting, and listing entities.
 
-```
+This can be done using either the ruby-based [`uaac` cli](https://github.com/cloudfoundry/cf-uaac):
+
+```sh
 uaac target uaa.<your system domain>
 uaac token client get admin -s <your uaa admin client secret>
 uaac client add cf-mgmt \
   --name cf-mgmt \
   --secret <client secret from cf-mgmt client> \
+  --authorized_grant_types client_credentials,refresh_token \
+  --authorities cloud_controller.admin,scim.read,scim.write,routing.router_groups.read
+```
+
+Or the [golang-based UAA CLI](https://github.com/cloudfoundry-incubator/uaa-cli):
+
+```sh
+uaa target https://uaa.<your system domain>
+uaa get-client-credentials-token admin -s <your uaa admin client secret>
+uaa create-client cf-mgmt \
+  --client_secret <client secret from cf-mgmt client> \
   --authorized_grant_types client_credentials,refresh_token \
   --authorities cloud_controller.admin,scim.read,scim.write,routing.router_groups.read
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ The following commands are enabled with cf-mgmt that will leverage configuration
 
 ## Authentication requirements
 
-Introduced in cf-mgmt 0.0.66+ is the ability to definee a non admin uaa client.  With this release the password field has been deprecated. To create a non-admin client execute the following command with [Cloud Foundry UAA Client](https://github.com/cloudfoundry/cf-uaac).
+Introduced in cf-mgmt 0.0.66+ is the ability to define a non admin uaa client.  With this release the password field has been deprecated. To create a non-admin client execute the following command with [Cloud Foundry UAA Client](https://github.com/cloudfoundry/cf-uaac).
 
 ```sh
 $ uaac target uaa.<system-domain>


### PR DESCRIPTION
Fixup of docs PR which forgot to include `uaa` example on main README.md page https://github.com/pivotalservices/cf-mgmt/pull/185

see also: https://github.com/pivotalservices/cf-mgmt/issues/182#issuecomment-514728347

for future reference, would it be better to make these kinds of (admittantly super minor) PRs against an active dev branch?