### PR TITLE
Trivial fix in documentation for 'cf-mgmt-config org'

### DIFF
--- a/docs/config/org/README.md
+++ b/docs/config/org/README.md
@@ -75,15 +75,9 @@ auditor:
       --auditor-ldap-group-to-remove=                     Group to remove, specify multiple times
 
 service-access:
-<<<<<<< HEAD
-      --service=                                          Service Name to add
-      --plans=                                            plans to add, empty list will add all plans
-      --service-to-remove=                                name of service to remove
-=======
-      --service=                                          *** Deprecated *** Service Name to add
-      --plans=                                            *** Deprecated *** plans to add, empty list will add all plans
-      --service-to-remove=                                *** Deprecated *** name of service to remove
->>>>>>> develop
+      --service=                                          *****DEPRECATED, use 'cf-mgmt-config global service-access' ***** - Service Name to add
+      --plans=                                            *****DEPRECATED, use 'cf-mgmt-config global service-access' ***** - plans to add, empty list will add all plans
+      --service-to-remove=                                *****DEPRECATED, use 'cf-mgmt-config global service-access' ***** - name of service to remove
 
 metadata:
       --label=                                      Label to add, can specify multiple


### PR DESCRIPTION
Hi Caleb,

Thank you for your great and constant work on `cf-mgmt`.

Here in this PR, I'm resolving some conflict mark that appeared last summer, and I updated the documentation so that it matches the output of `cf-mgmt-config org -h`, as obtained with latest version 1.0.36.

Best,
Benjamin